### PR TITLE
Bump requirements

### DIFF
--- a/custom_components/eufy_security/manifest.json
+++ b/custom_components/eufy_security/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/eufy_security",
   "requirements": [
-    "python-eufy-security==0.3.2"
+    "python-eufy-security==0.3.1"
   ],
   "dependencies": [
     "ffmpeg"

--- a/custom_components/eufy_security/manifest.json
+++ b/custom_components/eufy_security/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/eufy_security",
   "requirements": [
-    "python-eufy-security==0.3.0"
+    "python-eufy-security==0.3.2"
   ],
   "dependencies": [
     "ffmpeg"


### PR DESCRIPTION
Resolves https://github.com/nonsleepr/ha-eufy-security/issues/5

I think this should be all we need to do to stop the error flood.