### PR TITLE
Adding version number to manifest

### DIFF
--- a/custom_components/eufy_security/manifest.json
+++ b/custom_components/eufy_security/manifest.json
@@ -11,5 +11,6 @@
   ],
   "codeowners": [
       "@nonsleepr"
-  ]
+  ],
+  "version": "0.3.0"
 }


### PR DESCRIPTION
Fixes warning:
```
2021-03-04 11:35:05 WARNING (MainThread) [homeassistant.loader] No 'version' key in the manifest file for custom integration 'eufy_security'. This will not be allowed in a future version of Home Assistant. Please report this to the maintainer of 'eufy_security'
```