### PR TITLE
Update version for new release

### DIFF
--- a/custom_components/eufy_security/manifest.json
+++ b/custom_components/eufy_security/manifest.json
@@ -12,5 +12,5 @@
   "codeowners": [
       "@nonsleepr"
   ],
-  "version": "0.3.0"
+  "version": "0.3.1"
 }


### PR DESCRIPTION
The version needs to be updated for a new release to be created. This follows the previous PR adding a version number: https://github.com/nonsleepr/ha-eufy-security/pull/35

Hopefully this should make the plugin work again.