### PR TITLE
Fixing missing version in manifest

### DIFF
--- a/custom_components/eufy_security/manifest.json
+++ b/custom_components/eufy_security/manifest.json
@@ -2,6 +2,7 @@
   "domain": "eufy_security",
   "name": "Eufy Security",
   "config_flow": true,
+  "version": "1.0.0",
   "documentation": "https://www.home-assistant.io/integrations/eufy_security",
   "requirements": [
     "python-eufy-security==0.3.1"


### PR DESCRIPTION
Corrects error with latest HA builds: 
```
The custom integration 'eufy_security' does not have a valid version key
```